### PR TITLE
Fix typo in comment of samples_to_complex method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ pub fn samples_fft_to_spectrum(
     )
 }
 
-/// Converts all samples to a complex number (imaginary part is set to two)
+/// Converts all samples to a complex number (imaginary part is set to zero)
 /// as preparation for the FFT.
 ///
 /// ## Parameters


### PR DESCRIPTION
I'm currently trying to understand how to actually use rustfft to do create a spectrum analyzer and your code & comments are veeery helpful and a great insight! So first thanks a lot for this. Second, I think I found a typo? Not sure. I don't know shit about this :P