### PR TITLE
Add FFT buffer size of 32768

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Added FFT buffer size of 32768
+
 ## 1.6.0 (2024-12-16)
 - dependency updates
 - MSRV bump but only for the tests and examples, not library users

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ harness = false
 [dependencies]
 float-cmp = "~0.10.0"
 libm = "~0.2.7"
-microfft = { version = "~0.5.1", features = ["size-16384"] }
+microfft = { version = "~0.6.0", features = ["size-32768"] }
 paste = "~1.0.14"
 
 [dev-dependencies]

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -69,8 +69,9 @@ impl FftImpl {
     ///              a power of two. Otherwise, the function panics.
     #[inline]
     pub(crate) fn calc(samples: &[f32]) -> Vec<Complex32> {
-        let mut fft_res: Vec<Complex32> =
-            real_fft_n!(samples, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384);
+        let mut fft_res: Vec<Complex32> = real_fft_n!(
+            samples, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768
+        );
 
         // `microfft::real` documentation says: the Nyquist frequency real value
         // is packed inside the imaginary part of the DC component.


### PR DESCRIPTION
**Context for this pull request:** The powers of 2 shown here go up to 16384, and I wish to add a few more power of 2's worth of buffer sizes to the mix.

The Terrific Audio Driver by Undisbeliever calls `samples_fft_to_spectrum` when analyzing a BRR sample (this is created for the SPC700, which has a 64KB limit) by calculating a spectrum in one go (thus, if the samples are large enough they tend to request a buffer size large enough). This works fine up to 16384 samples, but a BRR sample can theoretically be as large as 116496 (though in practice it is usually smaller than this). The result is a panic.

**Context for the code in question:**
https://github.com/undisbeliever/terrific-audio-driver/blob/241c53fa3706bc89f3190ab7627145c29122c9ce/crates/tad-gui/src/sample_analyser.rs#L926

The code was since amended to limit the analysis size to 16384 samples for the time being. I determined that microfft only goes up to 32768...